### PR TITLE
Add optional software installation targets for personal machines

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Philip Leung
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,7 @@ required_packages=(
   libssl-dev
   libxmlsec1-dev
   libxml2-dev
+  ninja-build
   openjdk-11-jdk
   openvpn
   python3-dev

--- a/justfile
+++ b/justfile
@@ -502,6 +502,12 @@ verify-install:
         echo "⚠️ nvim not installed"
     fi
     
+    if command -v ninja >/dev/null 2>&1; then
+        echo "✓ ninja: $(ninja --version)"
+    else
+        echo "⚠️ ninja not installed"
+    fi
+    
     echo -e "\n--- Checking additional tools ---"
     for tool in cruft dive hadolint lazydocker just; do
         if command -v $tool >/dev/null 2>&1; then


### PR DESCRIPTION
- Add check to skip optional installs on EC2/cloud instances (ubuntu user)
- Add PyMol installation from Google Storage
- Add Slack installation from official DEB package
- Add Docker rootless installation per official instructions
- Add AWS VPN Client installation from official repository
- Add main optional-installs target to the default recipe
